### PR TITLE
feat: add prowlarr and qbittorrent support

### DIFF
--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -80,6 +80,27 @@ export interface SonarrSettings extends DVRSettings {
   enableSeasonFolders: boolean;
 }
 
+export interface ProwlarrSettings {
+  id: number;
+  name: string;
+  hostname: string;
+  port: number;
+  apiKey: string;
+  useSsl: boolean;
+  baseUrl?: string;
+}
+
+export interface QbittorrentSettings {
+  id: number;
+  name: string;
+  hostname: string;
+  port: number;
+  useSsl: boolean;
+  username: string;
+  password: string;
+  baseUrl?: string;
+}
+
 interface Quota {
   quotaLimit?: number;
   quotaDays?: number;
@@ -265,6 +286,8 @@ interface AllSettings {
   tautulli: TautulliSettings;
   radarr: RadarrSettings[];
   sonarr: SonarrSettings[];
+  prowlarr: ProwlarrSettings[];
+  qbittorrent: QbittorrentSettings[];
   public: PublicSettings;
   notifications: NotificationSettings;
   jobs: Record<JobId, JobSettings>;
@@ -312,6 +335,8 @@ class Settings {
       tautulli: {},
       radarr: [],
       sonarr: [],
+      prowlarr: [],
+      qbittorrent: [],
       public: {
         initialized: false,
       },
@@ -480,6 +505,22 @@ class Settings {
 
   set sonarr(data: SonarrSettings[]) {
     this.data.sonarr = data;
+  }
+
+  get prowlarr(): ProwlarrSettings[] {
+    return this.data.prowlarr;
+  }
+
+  set prowlarr(data: ProwlarrSettings[]) {
+    this.data.prowlarr = data;
+  }
+
+  get qbittorrent(): QbittorrentSettings[] {
+    return this.data.qbittorrent;
+  }
+
+  set qbittorrent(data: QbittorrentSettings[]) {
+    this.data.qbittorrent = data;
   }
 
   get public(): PublicSettings {

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -35,12 +35,16 @@ import { URL } from 'url';
 import notificationRoutes from './notifications';
 import radarrRoutes from './radarr';
 import sonarrRoutes from './sonarr';
+import prowlarrRoutes from './prowlarr';
+import qbittorrentRoutes from './qbittorrent';
 
 const settingsRoutes = Router();
 
 settingsRoutes.use('/notifications', notificationRoutes);
 settingsRoutes.use('/radarr', radarrRoutes);
 settingsRoutes.use('/sonarr', sonarrRoutes);
+settingsRoutes.use('/prowlarr', prowlarrRoutes);
+settingsRoutes.use('/qbittorrent', qbittorrentRoutes);
 settingsRoutes.use('/discover', discoverSettingRoutes);
 
 const filteredMainSettings = (

--- a/server/routes/settings/prowlarr.ts
+++ b/server/routes/settings/prowlarr.ts
@@ -1,0 +1,44 @@
+import type { ProwlarrSettings } from '@server/lib/settings';
+import { getSettings } from '@server/lib/settings';
+import { Router } from 'express';
+
+const prowlarrRoutes = Router();
+
+prowlarrRoutes.get('/', (_req, res) => {
+  const settings = getSettings();
+  return res.status(200).json(settings.prowlarr);
+});
+
+prowlarrRoutes.post('/', (req, res) => {
+  const settings = getSettings();
+  const newIndexer = req.body as ProwlarrSettings;
+  const last = settings.prowlarr[settings.prowlarr.length - 1];
+  newIndexer.id = last ? last.id + 1 : 0;
+  settings.prowlarr = [...settings.prowlarr, newIndexer];
+  settings.save();
+  return res.status(201).json(newIndexer);
+});
+
+prowlarrRoutes.put('/:id', (req, res, next) => {
+  const settings = getSettings();
+  const idx = settings.prowlarr.findIndex((p) => p.id === Number(req.params.id));
+  if (idx === -1) {
+    return next({ status: 404, message: 'Settings instance not found' });
+  }
+  settings.prowlarr[idx] = { ...req.body, id: Number(req.params.id) } as ProwlarrSettings;
+  settings.save();
+  return res.status(200).json(settings.prowlarr[idx]);
+});
+
+prowlarrRoutes.delete('/:id', (req, res, next) => {
+  const settings = getSettings();
+  const idx = settings.prowlarr.findIndex((p) => p.id === Number(req.params.id));
+  if (idx === -1) {
+    return next({ status: 404, message: 'Settings instance not found' });
+  }
+  const removed = settings.prowlarr.splice(idx, 1);
+  settings.save();
+  return res.status(200).json(removed[0]);
+});
+
+export default prowlarrRoutes;

--- a/server/routes/settings/qbittorrent.ts
+++ b/server/routes/settings/qbittorrent.ts
@@ -1,0 +1,47 @@
+import type { QbittorrentSettings } from '@server/lib/settings';
+import { getSettings } from '@server/lib/settings';
+import { Router } from 'express';
+
+const qbittorrentRoutes = Router();
+
+qbittorrentRoutes.get('/', (_req, res) => {
+  const settings = getSettings();
+  return res.status(200).json(settings.qbittorrent);
+});
+
+qbittorrentRoutes.post('/', (req, res) => {
+  const settings = getSettings();
+  const newClient = req.body as QbittorrentSettings;
+  const last = settings.qbittorrent[settings.qbittorrent.length - 1];
+  newClient.id = last ? last.id + 1 : 0;
+  settings.qbittorrent = [...settings.qbittorrent, newClient];
+  settings.save();
+  return res.status(201).json(newClient);
+});
+
+qbittorrentRoutes.put('/:id', (req, res, next) => {
+  const settings = getSettings();
+  const idx = settings.qbittorrent.findIndex((p) => p.id === Number(req.params.id));
+  if (idx === -1) {
+    return next({ status: 404, message: 'Settings instance not found' });
+  }
+  settings.qbittorrent[idx] = {
+    ...req.body,
+    id: Number(req.params.id),
+  } as QbittorrentSettings;
+  settings.save();
+  return res.status(200).json(settings.qbittorrent[idx]);
+});
+
+qbittorrentRoutes.delete('/:id', (req, res, next) => {
+  const settings = getSettings();
+  const idx = settings.qbittorrent.findIndex((p) => p.id === Number(req.params.id));
+  if (idx === -1) {
+    return next({ status: 404, message: 'Settings instance not found' });
+  }
+  const removed = settings.qbittorrent.splice(idx, 1);
+  settings.save();
+  return res.status(200).json(removed[0]);
+});
+
+export default qbittorrentRoutes;

--- a/src/components/Settings/ProwlarrModal.tsx
+++ b/src/components/Settings/ProwlarrModal.tsx
@@ -1,0 +1,135 @@
+import Modal from '@app/components/Common/Modal';
+import SensitiveInput from '@app/components/Common/SensitiveInput';
+import globalMessages from '@app/i18n/globalMessages';
+import type { ProwlarrSettings } from '@server/lib/settings';
+import axios from 'axios';
+import { Field, Formik } from 'formik';
+import { useIntl, defineMessages } from 'react-intl';
+import { useToasts } from 'react-toast-notifications';
+import * as Yup from 'yup';
+
+const messages = defineMessages({
+  addIndexer: 'Add Prowlarr Server',
+  editIndexer: 'Edit Prowlarr Server',
+  servername: 'Server Name',
+  hostname: 'Hostname or IP Address',
+  port: 'Port',
+  apiKey: 'API Key',
+  ssl: 'Use SSL',
+});
+
+interface ProwlarrModalProps {
+  prowlarr: ProwlarrSettings | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+const ProwlarrModal = ({ prowlarr, onClose, onSave }: ProwlarrModalProps) => {
+  const intl = useIntl();
+  const { addToast } = useToasts();
+
+  return (
+    <Formik
+      initialValues={{
+        name: prowlarr?.name ?? '',
+        hostname: prowlarr?.hostname ?? '',
+        port: prowlarr?.port ?? 9696,
+        apiKey: prowlarr?.apiKey ?? '',
+        useSsl: prowlarr?.useSsl ?? false,
+        baseUrl: prowlarr?.baseUrl ?? '',
+      }}
+      validationSchema={Yup.object({
+        name: Yup.string().required('Required'),
+        hostname: Yup.string().required('Required'),
+        port: Yup.number().required('Required'),
+        apiKey: Yup.string().required('Required'),
+      })}
+      onSubmit={async (values) => {
+        try {
+          if (prowlarr) {
+            await axios.put(`/api/v1/settings/prowlarr/${prowlarr.id}`, values);
+          } else {
+            await axios.post('/api/v1/settings/prowlarr', values);
+          }
+          addToast(intl.formatMessage(globalMessages.save), {
+            appearance: 'success',
+            autoDismiss: true,
+          });
+          onSave();
+        } catch (e) {
+          addToast('Failed to save', { appearance: 'error', autoDismiss: true });
+        }
+      }}
+    >
+      {({ errors, touched, isSubmitting, handleSubmit }) => (
+        <Modal
+          title={intl.formatMessage(
+            prowlarr ? messages.editIndexer : messages.addIndexer
+          )}
+          onOk={() => handleSubmit()}
+          onCancel={onClose}
+          okDisabled={isSubmitting}
+          okText={intl.formatMessage(globalMessages.save)}
+          cancelText={intl.formatMessage(globalMessages.cancel)}
+        >
+          <div className="space-y-2">
+            <label htmlFor="name" className="block text-sm font-medium">
+              {intl.formatMessage(messages.servername)}
+            </label>
+            <Field
+              id="name"
+              name="name"
+              className="w-full rounded-md border border-gray-500 bg-gray-700 p-2 text-white"
+            />
+            {errors.name && touched.name && (
+              <div className="text-sm text-red-500">{errors.name}</div>
+            )}
+            <label htmlFor="hostname" className="block text-sm font-medium">
+              {intl.formatMessage(messages.hostname)}
+            </label>
+            <Field
+              id="hostname"
+              name="hostname"
+              className="w-full rounded-md border border-gray-500 bg-gray-700 p-2 text-white"
+            />
+            {errors.hostname && touched.hostname && (
+              <div className="text-sm text-red-500">{errors.hostname}</div>
+            )}
+            <label htmlFor="port" className="block text-sm font-medium">
+              {intl.formatMessage(messages.port)}
+            </label>
+            <Field
+              id="port"
+              name="port"
+              type="number"
+              className="w-full rounded-md border border-gray-500 bg-gray-700 p-2 text-white"
+            />
+            {errors.port && touched.port && (
+              <div className="text-sm text-red-500">{errors.port}</div>
+            )}
+            <label htmlFor="apiKey" className="block text-sm font-medium">
+              {intl.formatMessage(messages.apiKey)}
+            </label>
+            <Field
+              id="apiKey"
+              name="apiKey"
+              as={SensitiveInput}
+              className="w-full rounded-md border border-gray-500 bg-gray-700 p-2 text-white"
+            />
+            {errors.apiKey && touched.apiKey && (
+              <div className="text-sm text-red-500">{errors.apiKey}</div>
+            )}
+            <div className="flex items-center space-x-2 pt-2">
+              <Field type="checkbox" id="useSsl" name="useSsl" />
+              <label htmlFor="useSsl" className="text-sm">
+                {intl.formatMessage(messages.ssl)}
+              </label>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </Formik>
+  );
+};
+
+export default ProwlarrModal;

--- a/src/components/Settings/QbittorrentModal.tsx
+++ b/src/components/Settings/QbittorrentModal.tsx
@@ -1,0 +1,149 @@
+import Modal from '@app/components/Common/Modal';
+import SensitiveInput from '@app/components/Common/SensitiveInput';
+import globalMessages from '@app/i18n/globalMessages';
+import type { QbittorrentSettings } from '@server/lib/settings';
+import axios from 'axios';
+import { Field, Formik } from 'formik';
+import { useIntl, defineMessages } from 'react-intl';
+import { useToasts } from 'react-toast-notifications';
+import * as Yup from 'yup';
+
+const messages = defineMessages({
+  addClient: 'Add qBittorrent Server',
+  editClient: 'Edit qBittorrent Server',
+  servername: 'Server Name',
+  hostname: 'Hostname or IP Address',
+  port: 'Port',
+  username: 'Username',
+  password: 'Password',
+  ssl: 'Use SSL',
+});
+
+interface QbittorrentModalProps {
+  client: QbittorrentSettings | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+const QbittorrentModal = ({ client, onClose, onSave }: QbittorrentModalProps) => {
+  const intl = useIntl();
+  const { addToast } = useToasts();
+
+  return (
+    <Formik
+      initialValues={{
+        name: client?.name ?? '',
+        hostname: client?.hostname ?? '',
+        port: client?.port ?? 8080,
+        username: client?.username ?? '',
+        password: client?.password ?? '',
+        useSsl: client?.useSsl ?? false,
+        baseUrl: client?.baseUrl ?? '',
+      }}
+      validationSchema={Yup.object({
+        name: Yup.string().required('Required'),
+        hostname: Yup.string().required('Required'),
+        port: Yup.number().required('Required'),
+        username: Yup.string().required('Required'),
+        password: Yup.string().required('Required'),
+      })}
+      onSubmit={async (values) => {
+        try {
+          if (client) {
+            await axios.put(`/api/v1/settings/qbittorrent/${client.id}`, values);
+          } else {
+            await axios.post('/api/v1/settings/qbittorrent', values);
+          }
+          addToast(intl.formatMessage(globalMessages.save), {
+            appearance: 'success',
+            autoDismiss: true,
+          });
+          onSave();
+        } catch (e) {
+          addToast('Failed to save', { appearance: 'error', autoDismiss: true });
+        }
+      }}
+    >
+      {({ errors, touched, isSubmitting, handleSubmit }) => (
+        <Modal
+          title={intl.formatMessage(
+            client ? messages.editClient : messages.addClient
+          )}
+          onOk={() => handleSubmit()}
+          onCancel={onClose}
+          okDisabled={isSubmitting}
+          okText={intl.formatMessage(globalMessages.save)}
+          cancelText={intl.formatMessage(globalMessages.cancel)}
+        >
+          <div className="space-y-2">
+            <label htmlFor="name" className="block text-sm font-medium">
+              {intl.formatMessage(messages.servername)}
+            </label>
+            <Field
+              id="name"
+              name="name"
+              className="w-full rounded-md border border-gray-500 bg-gray-700 p-2 text-white"
+            />
+            {errors.name && touched.name && (
+              <div className="text-sm text-red-500">{errors.name}</div>
+            )}
+            <label htmlFor="hostname" className="block text-sm font-medium">
+              {intl.formatMessage(messages.hostname)}
+            </label>
+            <Field
+              id="hostname"
+              name="hostname"
+              className="w-full rounded-md border border-gray-500 bg-gray-700 p-2 text-white"
+            />
+            {errors.hostname && touched.hostname && (
+              <div className="text-sm text-red-500">{errors.hostname}</div>
+            )}
+            <label htmlFor="port" className="block text-sm font-medium">
+              {intl.formatMessage(messages.port)}
+            </label>
+            <Field
+              id="port"
+              name="port"
+              type="number"
+              className="w-full rounded-md border border-gray-500 bg-gray-700 p-2 text-white"
+            />
+            {errors.port && touched.port && (
+              <div className="text-sm text-red-500">{errors.port}</div>
+            )}
+            <label htmlFor="username" className="block text-sm font-medium">
+              {intl.formatMessage(messages.username)}
+            </label>
+            <Field
+              id="username"
+              name="username"
+              className="w-full rounded-md border border-gray-500 bg-gray-700 p-2 text-white"
+            />
+            {errors.username && touched.username && (
+              <div className="text-sm text-red-500">{errors.username}</div>
+            )}
+            <label htmlFor="password" className="block text-sm font-medium">
+              {intl.formatMessage(messages.password)}
+            </label>
+            <Field
+              id="password"
+              name="password"
+              as={SensitiveInput}
+              className="w-full rounded-md border border-gray-500 bg-gray-700 p-2 text-white"
+            />
+            {errors.password && touched.password && (
+              <div className="text-sm text-red-500">{errors.password}</div>
+            )}
+            <div className="flex items-center space-x-2 pt-2">
+              <Field type="checkbox" id="useSsl" name="useSsl" />
+              <label htmlFor="useSsl" className="text-sm">
+                {intl.formatMessage(messages.ssl)}
+              </label>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </Formik>
+  );
+};
+
+export default QbittorrentModal;

--- a/src/components/Settings/SettingsDownloadClient.tsx
+++ b/src/components/Settings/SettingsDownloadClient.tsx
@@ -1,0 +1,95 @@
+import Alert from '@app/components/Common/Alert';
+import Button from '@app/components/Common/Button';
+import LoadingSpinner from '@app/components/Common/LoadingSpinner';
+import PageTitle from '@app/components/Common/PageTitle';
+import QbittorrentModal from '@app/components/Settings/QbittorrentModal';
+import globalMessages from '@app/i18n/globalMessages';
+import type { QbittorrentSettings } from '@server/lib/settings';
+import axios from 'axios';
+import { useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import useSWR, { mutate } from 'swr';
+
+const messages = defineMessages({
+  clients: 'Download Client',
+  addClient: 'Add qBittorrent Server',
+  address: 'Address',
+  error: 'Error',
+});
+
+const SettingsDownloadClient = () => {
+  const intl = useIntl();
+  const { data, error } = useSWR<QbittorrentSettings[]>(
+    '/api/v1/settings/qbittorrent'
+  );
+  const [modalState, setModalState] = useState<{
+    open: boolean;
+    client: QbittorrentSettings | null;
+  }>({ open: false, client: null });
+
+  if (!data && !error) {
+    return <LoadingSpinner />;
+  }
+
+  const revalidate = () => mutate('/api/v1/settings/qbittorrent');
+
+  return (
+    <>
+      <PageTitle title={intl.formatMessage(messages.clients)} />
+      <div className="mb-2 flex justify-end">
+        <Button onClick={() => setModalState({ open: true, client: null })}>
+          {intl.formatMessage(messages.addClient)}
+        </Button>
+      </div>
+      {error && (
+        <Alert title={intl.formatMessage(messages.error)} type="error">
+          {error.message}
+        </Alert>
+      )}
+      <ul className="space-y-4">
+        {data?.map((cl) => (
+          <li
+            key={`client-${cl.id}`}
+            className="flex items-center justify-between rounded-lg bg-gray-800 p-4"
+          >
+            <div>
+              <div className="text-white">{cl.name}</div>
+              <div className="text-sm text-gray-300">
+                {intl.formatMessage(messages.address)}: {(cl.useSsl ? 'https://' : 'http://') + cl.hostname + ':' + cl.port}
+              </div>
+            </div>
+            <div className="space-x-2">
+              <Button
+                buttonType="warning"
+                onClick={() => setModalState({ open: true, client: cl })}
+              >
+                {intl.formatMessage(globalMessages.edit)}
+              </Button>
+              <Button
+                buttonType="danger"
+                onClick={async () => {
+                  await axios.delete(`/api/v1/settings/qbittorrent/${cl.id}`);
+                  revalidate();
+                }}
+              >
+                {intl.formatMessage(globalMessages.delete)}
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {modalState.open && (
+        <QbittorrentModal
+          client={modalState.client}
+          onClose={() => setModalState({ open: false, client: null })}
+          onSave={() => {
+            setModalState({ open: false, client: null });
+            revalidate();
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default SettingsDownloadClient;

--- a/src/components/Settings/SettingsIndexers.tsx
+++ b/src/components/Settings/SettingsIndexers.tsx
@@ -1,0 +1,93 @@
+import Alert from '@app/components/Common/Alert';
+import Button from '@app/components/Common/Button';
+import LoadingSpinner from '@app/components/Common/LoadingSpinner';
+import PageTitle from '@app/components/Common/PageTitle';
+import ProwlarrModal from '@app/components/Settings/ProwlarrModal';
+import globalMessages from '@app/i18n/globalMessages';
+import type { ProwlarrSettings } from '@server/lib/settings';
+import axios from 'axios';
+import { useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import useSWR, { mutate } from 'swr';
+
+const messages = defineMessages({
+  indexers: 'Search Indexers',
+  addIndexer: 'Add Prowlarr Server',
+  address: 'Address',
+  error: 'Error',
+});
+
+const SettingsIndexers = () => {
+  const intl = useIntl();
+  const { data, error } = useSWR<ProwlarrSettings[]>('/api/v1/settings/prowlarr');
+  const [modalState, setModalState] = useState<{
+    open: boolean;
+    indexer: ProwlarrSettings | null;
+  }>({ open: false, indexer: null });
+
+  if (!data && !error) {
+    return <LoadingSpinner />;
+  }
+
+  const revalidate = () => mutate('/api/v1/settings/prowlarr');
+
+  return (
+    <>
+      <PageTitle title={intl.formatMessage(messages.indexers)} />
+      <div className="mb-2 flex justify-end">
+        <Button onClick={() => setModalState({ open: true, indexer: null })}>
+          {intl.formatMessage(messages.addIndexer)}
+        </Button>
+      </div>
+      {error && (
+        <Alert title={intl.formatMessage(messages.error)} type="error">
+          {error.message}
+        </Alert>
+      )}
+      <ul className="space-y-4">
+        {data?.map((idx) => (
+          <li
+            key={`indexer-${idx.id}`}
+            className="flex items-center justify-between rounded-lg bg-gray-800 p-4"
+          >
+            <div>
+              <div className="text-white">{idx.name}</div>
+              <div className="text-sm text-gray-300">
+                {intl.formatMessage(messages.address)}: {(idx.useSsl ? 'https://' : 'http://') + idx.hostname + ':' + idx.port}
+              </div>
+            </div>
+            <div className="space-x-2">
+              <Button
+                buttonType="warning"
+                onClick={() => setModalState({ open: true, indexer: idx })}
+              >
+                {intl.formatMessage(globalMessages.edit)}
+              </Button>
+              <Button
+                buttonType="danger"
+                onClick={async () => {
+                  await axios.delete(`/api/v1/settings/prowlarr/${idx.id}`);
+                  revalidate();
+                }}
+              >
+                {intl.formatMessage(globalMessages.delete)}
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {modalState.open && (
+        <ProwlarrModal
+          prowlarr={modalState.indexer}
+          onClose={() => setModalState({ open: false, indexer: null })}
+          onSave={() => {
+            setModalState({ open: false, indexer: null });
+            revalidate();
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default SettingsIndexers;

--- a/src/components/Settings/SettingsLayout.tsx
+++ b/src/components/Settings/SettingsLayout.tsx
@@ -9,6 +9,8 @@ const messages = defineMessages({
   menuUsers: 'Users',
   menuPlexSettings: 'Plex',
   menuServices: 'Services',
+  menuIndexers: 'Search Indexers',
+  menuDownloadClient: 'Download Client',
   menuNotifications: 'Notifications',
   menuLogs: 'Logs',
   menuJobs: 'Jobs & Cache',
@@ -42,6 +44,16 @@ const SettingsLayout = ({ children }: SettingsLayoutProps) => {
       text: intl.formatMessage(messages.menuServices),
       route: '/settings/services',
       regex: /^\/settings\/services/,
+    },
+    {
+      text: intl.formatMessage(messages.menuIndexers),
+      route: '/settings/indexers',
+      regex: /^\/settings\/indexers/,
+    },
+    {
+      text: intl.formatMessage(messages.menuDownloadClient),
+      route: '/settings/download',
+      regex: /^\/settings\/download/,
     },
     {
       text: intl.formatMessage(messages.menuNotifications),

--- a/src/pages/settings/download.tsx
+++ b/src/pages/settings/download.tsx
@@ -1,0 +1,10 @@
+import SettingsDownloadClient from '@app/components/Settings/SettingsDownloadClient';
+import SettingsLayout from '@app/components/Settings/SettingsLayout';
+
+const SettingsDownloadPage = () => (
+  <SettingsLayout>
+    <SettingsDownloadClient />
+  </SettingsLayout>
+);
+
+export default SettingsDownloadPage;

--- a/src/pages/settings/indexers.tsx
+++ b/src/pages/settings/indexers.tsx
@@ -1,0 +1,10 @@
+import SettingsIndexers from '@app/components/Settings/SettingsIndexers';
+import SettingsLayout from '@app/components/Settings/SettingsLayout';
+
+const SettingsIndexersPage = () => (
+  <SettingsLayout>
+    <SettingsIndexers />
+  </SettingsLayout>
+);
+
+export default SettingsIndexersPage;


### PR DESCRIPTION
## Summary
- add Prowlarr and qBittorrent settings back-end routes
- expose new Search Indexers and Download Client sections in settings
- include modals to configure Prowlarr and qBittorrent servers

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn format` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6890e26b20a083279cc8b074d08df8e6